### PR TITLE
Initialize Next.js customer list app

### DIFF
--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -1,0 +1,19 @@
+import CustomerForm from '../../components/CustomerForm'
+import Link from 'next/link'
+
+export const metadata = {
+  title: '顧客追加',
+}
+
+export default function AddPage() {
+  return (
+    <div>
+      <div className="mb-4">
+        <Link href="/" className="text-blue-500 underline">
+          &larr; 戻る
+        </Link>
+      </div>
+      <CustomerForm />
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import './globals.css'
+import { ReactNode } from 'react'
+import { CustomerProvider } from '../contexts/CustomerContext'
+
+export const metadata = {
+  title: '顧客管理アプリ',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ja">
+      <body className="max-w-xl mx-auto p-4">
+        <CustomerProvider>
+          <header className="mb-4">
+            <h1 className="text-2xl font-bold">顧客管理アプリ</h1>
+          </header>
+          {children}
+        </CustomerProvider>
+      </body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,15 @@
+import CustomerList from '../components/CustomerList'
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <div className="mb-4 text-right">
+        <Link href="/add" className="text-blue-500 underline">
+          新規追加
+        </Link>
+      </div>
+      <CustomerList />
+    </div>
+  )
+}

--- a/components/CustomerForm.tsx
+++ b/components/CustomerForm.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useCustomers } from '../contexts/CustomerContext'
+
+export default function CustomerForm() {
+  const { addCustomer } = useCustomers()
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [memo, setMemo] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!/^\d{11}$/.test(phone)) {
+      setError('電話番号は11桁の数字で入力してください')
+      return
+    }
+    addCustomer({ name, phone, memo })
+    router.push('/')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && <p className="text-red-500">{error}</p>}
+      <div>
+        <label className="block mb-1">会社名</label>
+        <input
+          className="w-full border p-2 rounded"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">電話番号</label>
+        <input
+          className="w-full border p-2 rounded"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">メモ</label>
+        <textarea
+          className="w-full border p-2 rounded"
+          value={memo}
+          onChange={(e) => setMemo(e.target.value)}
+        />
+      </div>
+      <button
+        type="submit"
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        追加
+      </button>
+    </form>
+  )
+}

--- a/components/CustomerList.tsx
+++ b/components/CustomerList.tsx
@@ -1,0 +1,37 @@
+'use client'
+import Link from 'next/link'
+import { useCustomers } from '../contexts/CustomerContext'
+
+export default function CustomerList() {
+  const { customers, toggleStatus } = useCustomers()
+
+  if (customers.length === 0) {
+    return (
+      <div className="text-center py-10">
+        <p className="mb-4">顧客が登録されていません。</p>
+        <Link href="/add" className="text-blue-500 underline">
+          顧客を追加
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {customers.map((c) => (
+        <div key={c.id} className="p-4 border rounded flex justify-between items-center">
+          <div>
+            <p className="font-bold">{c.name}</p>
+            <p className="text-sm text-gray-600">{c.phone}</p>
+          </div>
+          <button
+            className={`px-3 py-1 text-sm rounded ${c.done ? 'bg-green-500 text-white' : 'bg-gray-300'}`}
+            onClick={() => toggleStatus(c.id)}
+          >
+            {c.done ? '対応済み' : '未対応'}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/contexts/CustomerContext.tsx
+++ b/contexts/CustomerContext.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+export type Customer = {
+  id: number
+  name: string
+  phone: string
+  memo: string
+  done: boolean
+}
+
+export type CustomerContextType = {
+  customers: Customer[]
+  addCustomer: (c: Omit<Customer, 'id' | 'done'>) => void
+  toggleStatus: (id: number) => void
+}
+
+const CustomerContext = createContext<CustomerContextType | undefined>(undefined)
+
+export const useCustomers = () => {
+  const ctx = useContext(CustomerContext)
+  if (!ctx) throw new Error('useCustomers must be used within Provider')
+  return ctx
+}
+
+export const CustomerProvider = ({ children }: { children: ReactNode }) => {
+  const [customers, setCustomers] = useState<Customer[]>([])
+
+  const addCustomer = (c: Omit<Customer, 'id' | 'done'>) => {
+    setCustomers(prev => [...prev, { ...c, id: Date.now(), done: false }])
+  }
+
+  const toggleStatus = (id: number) => {
+    setCustomers(prev => prev.map(c => (c.id === id ? { ...c, done: !c.done } : c)))
+  }
+
+  return (
+    <CustomerContext.Provider value={{ customers, addCustomer, toggleStatus }}>
+      {children}
+    </CustomerContext.Provider>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "websales-app",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.12",
+    "postcss": "^8.4.18",
+    "tailwindcss": "^3.1.8",
+    "typescript": "^5.1.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup Next.js 13 project with TypeScript and Tailwind CSS
- implement context for customer data stored in memory
- add home page with customer list and status toggle
- add page with customer registration form and validation

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685414ec08d88325bbb273e9a2083532